### PR TITLE
Add Certbot for SSL management and configure Docker volumes

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -16,6 +16,8 @@ RUN pnpm run build
 # Run phase
 FROM nginx:stable-alpine-perl
 
+RUN apk add --no-cache certbot certbot-nginx
+
 COPY --from=build /app/.nginx/nginx.conf /etc/nginx/conf.d/nginx.conf
 
 RUN rm /etc/nginx/conf.d/default.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,12 @@ services:
       - 443:443
     networks:
       - creator-awards-network
+    volumes:
+      - letsencrypt:/etc/letsencrypt
 
 networks:
   creator-awards-network:
     driver: bridge
+
+volumes:
+  letsencrypt:


### PR DESCRIPTION
Integrate Certbot for managing SSL certificates and set up Docker volumes for Let's Encrypt in the application.