### PR TITLE
Fix event timestamp accuracy and add restart policy to Docker services

### DIFF
--- a/client/src/consts/event-date.ts
+++ b/client/src/consts/event-date.ts
@@ -1,4 +1,4 @@
-export const EVENT_TIMESTAMP = 1737828000000 as const;
+export const EVENT_TIMESTAMP = 1741132800000 as const;
 
 /*
  Mapeo de Abreviaturas de Zonas Horarias

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: ./api
       dockerfile: Dockerfile
+    restart: always
     env_file: ./api/.env
     ports:
       - 5432:5432
@@ -13,6 +14,7 @@ services:
     build:
       context: ./client
       dockerfile: Dockerfile
+    restart: always
     ports:
       - 80:80
       - 443:443


### PR DESCRIPTION
Update the event timestamp for improved accuracy and implement a restart policy for services in the Docker Compose configuration.